### PR TITLE
parse the target specification file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,16 @@ matrix:
   exclude:
     - rust: nightly
   include:
-    - env: TARGET=x86_64-unknown-linux-gnu
+    - env: TARGET=cortex-m3
+      dist: trusty
+      sudo: required
+    - env: TARGET=no-linker-field
+      dist: trusty
+      sudo: required
     - env: TARGET=thumbv7m-none-eabi
       dist: trusty
       sudo: required
+    - env: TARGET=x86_64-unknown-linux-gnu
 
 before_install:
   - sudo apt-get update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,5 @@ version = "0.1.0"
 
 [build-dependencies]
 gcc = "0.3.27"
+serde_json = "0.7.0"
 tempdir = "0.3.4"
-
-[dependencies]

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ it's currently lacking a way to cross compile compiler-rt for custom targets.
 - You do **not** need to add `extern crate compiler_rt` anywhere.
 - For custom targets, make sure that the `no-compiler-rt` field is set to `false`, which is the
 default. If the field is missing from your specification file, that's OK.
-- For custom targets, the name of the target must match its `llvm-target` field. (See [caveats])
-- The variables `CC_${TARGET//-/_}` and `AR_${TARGET//-/_}`  must be set to `$prefix-gcc` and
-`$prefix-ar` respectively.
+- The `linker` field must be set to `$prefix-gcc` **or** the variables `CC_${TARGET//-/_}` and
+`AR_${TARGET//-/_}`  must be set to `$prefix-gcc` and `$prefix-ar` respectively. If both are set,
+the env variables take precedence.
 
 (\*) It's unclear to me what happens if *two different* versions of this crate appear in your
 dependency graph. Cargo will probably raise an error at link time.
@@ -45,21 +45,18 @@ $ tail -n2 Cargo.toml
 git = "https://github.com/japaric/compiler-rt.rs"
 
 # `no-compiler-rt` is not set
-$ cat thumbv7m-none-eabi.json | grep no-compiler-rt
+$ grep no-compiler-rt cortex-m3.json
 
-$ cat thumbv7m-none-eabi.json | grep llvm-target
-    "llvm-target": "thumbv7m-none-eabi",
+$ grep linker cortex-m3.json
+    "linker": "arm-none-eabi-gcc"
     
-$ export AR_thumbv7m_none_eabi=arm-none-eabi-ar
-$ export CC_thumbv7m_none_eabi=arm-none-eabi-gcc
-
-$ cargo build --target thumbv7m-none-eabi
+$ cargo build --target cortex-m3
 (..)
    Compiling compiler-rt v0.1.0
 (..)
    
 $ find -name '*.a'
-./target/thumbv7m-none-eabi/debug/build/compiler-rt-470fb48a4f2daa6c/out/libcompiler-rt.a
+./target/cortex-m3/debug/build/compiler-rt-d33efb9ff92c364e/out/libcompiler-rt.a
 ```
 
 ## Caveats
@@ -71,9 +68,6 @@ implemented and tested.
 - Requires `git` to be in your `$PATH`. This requirement will be lifted in the future.
 - Requires a nightly `rustc` because this crate is `no_core`, but it may make sense to make this
 crate `no_std` to make it usable with other channels.
-- The name of the target must match its `llvm-target` field. This limitation is due to the fact that
-build.rs can't access the value of the target's `llvm-target` field (or any other field). This
-limitation could be lifted if something like [rust-lang/rust#32988][0] is implemented.
 
 [0]: https://github.com/rust-lang/rust/pull/32988
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,7 +4,7 @@ set -ex
 
 main() {
     case $TARGET in
-        thumbv7m-none-eabi)
+        cortex-m* | no-linker-field | thumbv7m-none-eabi)
             sudo apt-get install -y --force-yes --no-install-recommends \
                  gcc-arm-none-eabi libnewlib-dev
             ;;

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,21 +3,12 @@ set -ex
 . $(dirname $0)/utils.sh
 
 main() {
-    local prefix=
     case $TARGET in
-        thumbv7m-none-eabi)
-            prefix=arm-none-eabi-
-            ;;
-        x86_64-unknown-linux-gnu)
-            prefix=
-            ;;
-        *)
-            die "unhandled target: $TARGET"
+        no-linker-field)
+            export AR_no_linker_field=arm-none-eabi-ar
+            export CC_no_linker_field=arm-none-eabi-gcc
             ;;
     esac
-
-    export AR_${TARGET//-/_}=${prefix}ar
-    export CC_${TARGET//-/_}=${prefix}gcc
 
     cargo build --target $TARGET
 }

--- a/cortex-m3.json
+++ b/cortex-m3.json
@@ -6,5 +6,6 @@
     "target-endian": "little",
     "target-pointer-width": "32",
 
+    "cpu": "cortex-m3",
     "linker": "arm-none-eabi-gcc"
 }

--- a/no-linker-field.json
+++ b/no-linker-field.json
@@ -4,7 +4,5 @@
     "llvm-target": "thumbv7m-none-eabi",
     "os": "none",
     "target-endian": "little",
-    "target-pointer-width": "32",
-
-    "linker": "arm-none-eabi-gcc"
+    "target-pointer-width": "32"
 }


### PR DESCRIPTION
this:
- lifts the restriction that the target name must match its
  `llvm-target` field.
- The `AR` and `CC` variables are not needed when the `linker` field is
  set.

closes #4
