### PR TITLE
Fix logic bug which causes all files to be blacklisted on cortex-m4

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -504,9 +504,9 @@ fn build(src: &Path, target: &Target) {
                 continue;
             }
 
-            if target.cpu() == Some("cortex-m4") ||
-               (target.cpu() == Some("cortex-m7") &&
-                target.features().map(|f| f.contains("+fp-only-sp")) == Some(true)) &&
+            if (target.cpu() == Some("cortex-m4") ||
+                           (target.cpu() == Some("cortex-m7") &&
+                            target.features().map(|f| f.contains("+fp-only-sp")) == Some(true))) &&
                SP_FPU_BLACKLIST.contains(source) {
                 continue;
             }


### PR DESCRIPTION
With this patch applied I can now build compiler-rt.rs for my Cortex-M4F (a TI LM4F120).
